### PR TITLE
Experiment with custom view for local notification on watchOS

### DIFF
--- a/Local Notifications Watch App/ContentView.swift
+++ b/Local Notifications Watch App/ContentView.swift
@@ -66,6 +66,9 @@ extension SessionDelegate: WCSessionDelegate {
 }
 
 struct LocalNotification {
+    static let messageKey = "message_key"
+    static let categoryKey = "notification_delay_test"
+    
     let message: String
     let logger = Logger(subsystem: "com.foreflight.watch.Local-Notifications.watchkitapp", category: "LocalNotification")
 
@@ -92,6 +95,8 @@ struct LocalNotification {
         content.title = message
         content.sound = .defaultCritical
         content.interruptionLevel = .timeSensitive
+        content.userInfo = [Self.messageKey: message]
+        content.categoryIdentifier = Self.categoryKey
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
         

--- a/Local Notifications Watch App/Local_NotificationsApp.swift
+++ b/Local Notifications Watch App/Local_NotificationsApp.swift
@@ -13,5 +13,9 @@ struct Local_Notifications_Watch_AppApp: App {
         WindowGroup {
             ContentView()
         }
+        
+        #if os(watchOS)
+        WKNotificationScene(controller: NotificationController.self, category: LocalNotification.categoryKey)
+        #endif
     }
 }

--- a/Local Notifications Watch App/NotificationView.swift
+++ b/Local Notifications Watch App/NotificationView.swift
@@ -1,0 +1,41 @@
+//
+//  NotificationView.swift
+//  Local Notifications Watch App
+//
+//  Created by Michael Harper on 11/14/23.
+//
+
+import WatchKit
+import SwiftUI
+import UserNotifications
+
+struct NotificationView: View {
+    var message: String?
+    
+    var body: some View {
+        VStack {
+            Image(systemName: "exclamationmark.bubble")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text(message ?? "Default message")
+                .font(.caption)
+        }
+    }
+}
+
+#Preview {
+    NotificationView(message: "You are here")
+}
+
+class NotificationController: WKUserNotificationHostingController<NotificationView> {
+    var message: String?
+    
+    override var body: NotificationView {
+        NotificationView(message: message)
+    }
+    
+    override func didReceive(_ notification: UNNotification) {
+        let notificationData = notification.request.content.userInfo as? [String: Any]
+        message = notificationData?[LocalNotification.messageKey] as? String
+    }
+}

--- a/Local Notifications.xcodeproj/project.pbxproj
+++ b/Local Notifications.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D87169E22B042F5300D7C984 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87169E12B042F5300D7C984 /* NotificationView.swift */; };
 		D8797D492AFD61650087DB38 /* Local_NotificationsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8797D482AFD61650087DB38 /* Local_NotificationsApp.swift */; };
 		D8797D4B2AFD61650087DB38 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8797D4A2AFD61650087DB38 /* ContentView.swift */; };
 		D8797D4D2AFD61660087DB38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8797D4C2AFD61660087DB38 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D87169E12B042F5300D7C984 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
 		D8797D452AFD61650087DB38 /* Local Notifications.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Local Notifications.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8797D482AFD61650087DB38 /* Local_NotificationsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Local_NotificationsApp.swift; sourceTree = "<group>"; };
 		D8797D4A2AFD61650087DB38 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				D8E7B0232AFD968500B27897 /* Local Notifications Watch App.entitlements */,
 				D8797D5A2AFD61660087DB38 /* Local_NotificationsApp.swift */,
 				D8797D5C2AFD61660087DB38 /* ContentView.swift */,
+				D87169E12B042F5300D7C984 /* NotificationView.swift */,
 				D8E7B0282AFD96E900B27897 /* KeepAlive.swift */,
 				D8797D5E2AFD61670087DB38 /* Assets.xcassets */,
 				D8797D602AFD61670087DB38 /* Preview Content */,
@@ -252,6 +255,7 @@
 				D8797D5D2AFD61660087DB38 /* ContentView.swift in Sources */,
 				D8797D5B2AFD61660087DB38 /* Local_NotificationsApp.swift in Sources */,
 				D8E7B0292AFD96E900B27897 /* KeepAlive.swift in Sources */,
+				D87169E22B042F5300D7C984 /* NotificationView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I figured I'd try creating a custom view for a local notification on watchOS to see if it had any impact on the 13-second delay presenting the notification. It doesn't, but this does serve as a simple guide to how you add a custom view for a local notification.

![Screenshot 2023-11-14 at 15 20 33](https://github.com/mharper-foreflight/Local-Notifications/assets/146022976/c0fa6bd0-ee64-4508-9921-9d6f79c7e483)
